### PR TITLE
fix: on progress callback

### DIFF
--- a/execute.go
+++ b/execute.go
@@ -406,8 +406,9 @@ func (f *Fetch) Execute() (*Response, error) {
 
 		if f.config.OnProgress != nil {
 			progress := &Progress{
-				Total:   resp.ContentLength,
-				Current: 0,
+				Total:    resp.ContentLength,
+				Current:  0,
+				Reporter: *f.config.OnProgress,
 			}
 
 			_, err = io.Copy(io.MultiWriter(file, progress), reader)


### PR DESCRIPTION
```go
package main

import (
        "fmt"

        "github.com/go-zoox/fetch"
)

func progress(percent int64, current int64, total int64) {
        fmt.Printf("PERCENT: %.2f, CURRENT: %d, TOTAL: %d\n", float64(current)/float64(total)*100, current, total)
}

func main() {
        fetch.New().
                Download("https://speed.hetzner.de/100MB.bin", "/tmp/test.db").
                SetProgressCallback(progress).
                Execute()
}
```
![image](https://github.com/go-zoox/fetch/assets/38805204/67b16a95-21eb-40e9-87cb-85a603c03576)
