### PR TITLE
feat: block body when request method is GET or HEAD

### DIFF
--- a/get.go
+++ b/get.go
@@ -9,5 +9,9 @@ func Get(url string, config ...interface{}) (*Response, error) {
 		return nil, ErrTooManyArguments
 	}
 
+	if c.Body != nil {
+        panic("Request with GET method cannot have body")
+    }
+
 	return New().Get(url, c).Execute()
 }

--- a/head.go
+++ b/head.go
@@ -9,5 +9,9 @@ func Head(url string, config ...interface{}) (*Response, error) {
 		return nil, ErrTooManyArguments
 	}
 
+	if c.Body != nil {
+        panic("Request with HEAD method cannot have body")
+    }
+
 	return New().Head(url, c).Execute()
 }


### PR DESCRIPTION
GET or HEAD request should not have a body according to both the HTTP/1.1 and HTTP/2 specifications.
This is a fix for that.